### PR TITLE
BSF-47 mvn site fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,13 @@
       <!-- <plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>jardiff-maven-plugin</artifactId> <configuration> <artifacts> 
         <artifact> <version>5.2</version> </artifact> <artifact> <groupId>bcel</groupId> <version>5.1</version> </artifact> </artifacts> 
         </configuration> </plugin> -->
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <doclint>none</doclint>
+        </configuration>
+      </plugin>
     </plugins>
   </reporting>
 

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -66,11 +66,11 @@ BSF 2.x supports several scripting languages currently:
 
 <ul>
    <li>
-       <a href="http://www.mozilla.org/rhino/">Javascript (using Rhino ECMAScript, from the Mozilla project)</a>
+       <a href="https://github.com/mozilla/rhino">Javascript (using Rhino ECMAScript, from the Mozilla project)</a>
    </li>
 
    <li>
-       <a href="http://www-306.ibm.com/software/awdtools/netrexx/">NetRexx</a> (an extension of the IBM REXX scripting language in Java)
+       <a href="https://netrexx.org/">NetRexx</a> (an extension of the IBM REXX scripting language in Java)
    </li>
 
    <li>
@@ -99,7 +99,7 @@ BSF 2.x supports several scripting languages currently:
    </li>
 
    <li>
-       <a href="http://groovy.codehaus.org/">Groovy</a>
+       <a href="https://groovy-lang.org/">Groovy</a>
    </li>
 
    <li>
@@ -111,11 +111,11 @@ BSF 2.x supports several scripting languages currently:
    </li>
 
    <li>
-       <a href="http://jruby.codehaus.org/">JRuby</a>
+       <a href="https://www.jruby.org/">JRuby</a>
    </li>
 
    <li>
-       <a href="http://www.judoscript.org">JudoScript</a>
+       <a href="https://metaprgmr.github.io/Judoscript/website/judoscript.com-v2/home.html">JudoScript</a>
    </li>
 
    <li>
@@ -190,7 +190,7 @@ with some implementations of javax.script (e.g. Sun Java 6) this may prevent any
 An example language which includes the necessary engine factory is:
 <a href="http://commons.apache.org/jexl/">Apache Jexl 2.0</a> (requires Java 5).
 Some other scripting languages also come with their own factories already included.
-For example <a href="http://groovy.codehaus.org/">Groovy</a> and <a href="http://jruby.org/">JRuby</a>.  
+For example <a href="https://groovy-lang.org/">Groovy</a> and <a href="https://jruby.org/">JRuby</a>.  
 </p>
 <p>
 Many other languages are supported by the 3rd party engine factories available at 

--- a/src/site/xdoc/projects.xml
+++ b/src/site/xdoc/projects.xml
@@ -82,11 +82,11 @@
           </tr>
           <tr>
             <th>URL:</th>
-            <td><a href="http://groovy.codehaus.org/">http://groovy.codehaus.org/</a></td>
+            <td><a href="https://groovy-lang.org/">https://groovy-lang.org/</a></td>
           </tr>
           <tr>
             <th>Contact:</th>
-            <td><a href="http://groovy.codehaus.org/mail-lists.html">Mailing lists</a></td>
+            <td><a href="http://groovy-lang.org/mailing-lists.html">Mailing lists</a></td>
           </tr>
           <tr>
             <th>License:</th>
@@ -134,7 +134,7 @@
           </tr>
           <tr>
             <th>URL:</th>
-            <td><a href="http://tcl.activestate.com/software/java/">http://tcl.activestate.com/software/java/</a></td>
+            <td><a href="https://tcljava.sourceforge.net/docs/website/index.html">https://tcljava.sourceforge.net/docs/website/index.html</a></td>
           </tr>
           <tr>
             <th>Contact:</th>
@@ -193,11 +193,11 @@
           </tr>
           <tr>
             <th>URL:</th>
-            <td><a href="http://www.mozilla.org/rhino/">http://www.mozilla.org/rhino/</a></td>
+            <td><a href="http://mozilla.github.io/rhino/">http://mozilla.github.io/rhino/</a></td>
           </tr>
           <tr>
             <th>Contact:</th>
-            <td><a href="http://www.mozilla.org/rhino/help.html">Rhino Contact Page</a></td>
+            <td><a href="https://github.com/mozilla/rhino">Rhino Contact Page</a></td>
           </tr>
           <tr>
             <th>License:</th>
@@ -280,7 +280,7 @@
           </tr>
           <tr>
             <th>URL:</th>
-            <td><a href="http://www.judoscript.com/">http://www.judoscript.com/</a></td>
+            <td><a href="https://metaprgmr.github.io/Judoscript/website/judoscript.com-v2/home.html">https://metaprgmr.github.io/Judoscript/website/judoscript.com-v2/home.html</a></td>
           </tr>
           <tr>
             <th>Contact:</th>
@@ -336,11 +336,11 @@
           </tr>
           <tr>
             <th>URL:</th>
-            <td><a href="http://www2.hursley.ibm.com/netrexx/">http://www2.hursley.ibm.com/netrexx/</a></td>
+            <td><a href="https://netrexx.org/">https://netrexx.org/</a></td>
           </tr>
           <tr>
             <th>Contact:</th>
-            <td><a href="http://www-306.ibm.com/software/awdtools/netrexx/mailinglist.html">NetRexx 2 mailing list</a></td>
+            <td><a href="https://netrexx.org/mailinglist.nsp">NetRexx 2 mailing list</a></td>
           </tr>
           <tr>
             <th>License:</th>


### PR DESCRIPTION
fixes site generation with jdk8 and the doclinter and fixes a number of dead links